### PR TITLE
Added spanish translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,4 +1,5 @@
 de
+es
 fr
 it
 nl

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,165 @@
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Luis Manuel Arrieta Ávila <lumanarav@gmail.com>, 2023.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-14 12:42+0100\n"
+"PO-Revision-Date: 2023-07-15 04:38-0600\n"
+"Last-Translator: Luis Manuel Arrieta Ávila <lumanarav@gmail.com>\n"
+"Language-Team: Spanish <kde-i18n-doc@kde.org>\n"
+"Language: es_MX\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 23.04.3\n"
+
+#: data/it.mijorus.whisper.desktop.in:3
+#: data/it.mijorus.whisper.appdata.xml.in:4
+msgid "Whisper"
+msgstr "Whisper"
+
+#: data/it.mijorus.whisper.appdata.xml.in:8
+msgid "Listen to your mic"
+msgstr "Escucha tu micrófono"
+
+#: data/it.mijorus.whisper.appdata.xml.in:9
+msgid "Lorenzo Paderi"
+msgstr "Lorenzo Paderi"
+
+#: data/it.mijorus.whisper.appdata.xml.in:13
+msgid ""
+"Whisper allows you to listen to your microphone through your speakers using "
+"Pipewire"
+msgstr ""
+"Whisper te permite escuchar tu micrófono a través de tus altavoces usando"
+" PipeWire"
+
+#: data/it.mijorus.whisper.appdata.xml.in:18
+msgid "- Added support for Bluetooth speakers"
+msgstr "- Agregado soporte para bocinas Bluetooth"
+
+#: data/it.mijorus.whisper.appdata.xml.in:19
+msgid "- Performance improvements"
+msgstr "- Mejoras de rendimiento"
+
+#: data/it.mijorus.whisper.appdata.xml.in:24
+msgid "- First release"
+msgstr "- Primer lanzamiento"
+
+#: data/it.mijorus.whisper.appdata.xml.in:30
+msgid "Application showcase"
+msgstr "Presentación de la aplicación"
+
+#: data/it.mijorus.whisper.appdata.xml.in:35
+msgid "Settings page"
+msgstr "Página de opciones"
+
+#: src/window.py:346
+msgid "Reloading last connections in "
+msgstr "Recargando las últimas conexiones en "
+
+#: src/window.py:346
+msgid " seconds..."
+msgstr " segundos..."
+
+#: src/main.py:110
+msgid "translator_credits"
+msgstr "L. Manuel Arrieta https://github.com/MasterGeekMX"
+
+#: src/components/NoLinksPlaceholder.py:10
+msgid "No active connections"
+msgstr "No hay conexiones activas"
+
+#: src/components/NoLinksPlaceholder.py:11
+msgid "To get started, connect a microphone and a speaker"
+msgstr "Para empezar, conecta un micrófono y un altavoz"
+
+#: src/components/PwActiveConnectionBox.py:78
+msgid "Disconnect"
+msgstr "Desconectar"
+
+#: src/components/PwActiveConnectionBox.py:85
+msgid "This connection will be closed when quitting the application"
+msgstr "Esta conexión será cerrada cuando salgas de la aplicación"
+
+#: src/components/PwConnectionBox.py:15
+msgid "Create a connection"
+msgstr "Crear una conexión"
+
+#: src/components/PwConnectionBox.py:18
+msgid " -- Select a microphone --"
+msgstr " -- Selecciona un micrófono --"
+
+#: src/components/PwConnectionBox.py:34
+msgid " -- Select a speaker --"
+msgstr " -- Selecciona un altavoz --"
+
+#: src/components/PwConnectionBox.py:51
+msgid "Connect"
+msgstr "Conectar"
+
+#: src/Preferences.py:18
+msgid "General"
+msgstr "General"
+
+#: src/Preferences.py:19
+msgid "Autostart"
+msgstr "Auto-iniciar"
+
+#: src/Preferences.py:21
+msgid "Show connection IDs"
+msgstr "Mostrar los ID de las conexiones"
+
+#: src/Preferences.py:21
+msgid "For the geeks out there"
+msgstr "Para los nerds que les interese"
+
+#: src/Preferences.py:23
+msgid "Start on boot"
+msgstr "Iniciar al arrancar"
+
+#: src/Preferences.py:23
+msgid "Open Whisper when the system starts"
+msgstr "Abrir Whisper cuando el sistema se inicia"
+
+#: src/Preferences.py:24
+msgid "Release connections on close"
+msgstr "Liberar las conexiones al cerrar"
+
+#: src/Preferences.py:24
+msgid "Closes all the connections created with Whisper when leaving the app"
+msgstr ""
+"Cierra todas las conexiones creadas con Whisper cuando se salga de la"
+" aplicación"
+
+#: src/Preferences.py:25
+msgid "Reconnect all the devices at startup"
+msgstr "Re-conectar todos los dispositivos al iniciar"
+
+#: src/Preferences.py:25
+msgid ""
+"Reload all the connections if they are no longer active. Unplugged devices "
+"will be skipped"
+msgstr ""
+"Recarga todas las conexiones si ya no están activas. Los dispositivos"
+" desconectados serán ignorados"
+
+#: src/gtk/main-menu.ui:6
+msgid "_Preferences"
+msgstr "_Preferencias"
+
+#: src/gtk/main-menu.ui:10
+msgid "_Debug Log"
+msgstr "Registro de _depuración"
+
+#: src/gtk/main-menu.ui:18
+msgid "_Translate this app"
+msgstr "_Traduce esta aplicación"
+
+#: src/gtk/main-menu.ui:22
+msgid "_About"
+msgstr "_Acerca de"


### PR DESCRIPTION
Great app. Love at first sight when I saw it on flathub.

Anyways, here is the Spanish translation for the app. Tried to keep it as neutral as possible because there is European Spanish and Latinamerican Spanish, and I aimed to be a translation that works on both.

BTW, lots of GNOME apps that have common words as name tend to translate the name of the app to the locale, and I think this could be the case. I left the name of the app untouched by the moment.