### PR TITLE
Appdata and translation related changes

### DIFF
--- a/data/it.mijorus.whisper.appdata.xml.in
+++ b/data/it.mijorus.whisper.appdata.xml.in
@@ -9,29 +9,29 @@
     <developer_name>Lorenzo Paderi</developer_name>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
-	<description>
+	<description translate="no">
 	  <p>Whisper allows you to listen to your microphone through your speakers using Pipewire</p>
 	</description>
     <releases>
     <release type="stable" version="1.1.6" date="2023-12-07T00:00:00Z">
-                <description>
+                <description translate="no">
                      <p>- Fixed an error causing settings toggles to be displayed incorrecly</p>
                 </description>
       </release>
     	<release type="stable" version="1.1.5" date="2023-02-14T00:00:00Z">
-                <description>
+                <description translate="no">
                     <p>- Added an option to terminate all the connections when closing the app</p>
                      <p>- Added turkish translation. Thanks to Sabri Ünal</p>
                 </description>
       </release>
     	<release type="stable" version="1.1.0" date="2023-02-09T00:00:00Z">
-                <description>
+                <description translate="no">
                     <p>- Added support for Bluetooth speakers</p>
                     <p>- Performance improvements</p>
                 </description>
         </release>
         <release type="stable" version="1.0.0" date="2023-02-05T00:00:00Z">
-            <description>
+            <description translate="no">
                 <p>- First release</p>
             </description>
         </release>

--- a/data/it.mijorus.whisper.appdata.xml.in
+++ b/data/it.mijorus.whisper.appdata.xml.in
@@ -7,6 +7,9 @@
     <url type="donation">https://ko-fi.com/mijorus</url>
     <summary>Listen to your mic</summary>
     <developer_name>Lorenzo Paderi</developer_name>
+    <developer id="it.mijorus">
+        <name>Lorenzo Paderi</name>
+    </developer>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
 	<description translate="no">


### PR DESCRIPTION
### appdata: Exclude release descriptions from translation

GNOME automatically excludes release descriptions on Damned Lies
(GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus
their efforts on more critical and user-facing aspects of the application.

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer