### PR TITLE
Add keywords to desktop entry for easier searching

### DIFF
--- a/data/it.mijorus.whisper.desktop.in
+++ b/data/it.mijorus.whisper.desktop.in
@@ -5,4 +5,5 @@ Icon=it.mijorus.whisper
 Terminal=false
 Type=Application
 Categories=Utility;GTK;
+Keywords=audio;micrphone;sound;voice;
 StartupNotify=true


### PR DESCRIPTION
Hi! Really loving this app to goof around with my voice.  
I just found it hard to search for, because I forget the name since I use it very rarely, so I thought we could add keywords to the desktop entry, this way it becomes quite a bit easier to search intuitively through generic things it has to do with.

---
Related documentation on the format: [Recognized desktop entry keys](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html), described at `Keywords` entry of the table.